### PR TITLE
Prepare custom fields

### DIFF
--- a/lib/attribrutex.ex
+++ b/lib/attribrutex.ex
@@ -125,6 +125,17 @@ defmodule Attribrutex do
     end
     ```
 
+  In case of detect a bad type for a field, an error will be added to
+  changeset.errors
+
+  ## Example
+
+    ```
+    #Ecto.Changeset<action: nil, changes: %{email: "example@example.com"},
+    errors: [custom_fields: {"Bad data type", [custom_field: :location]}],
+    data: #AttribrutexUser<>, valid?: false>
+    ```
+
   """
   @spec prepare_custom_fields(Ecto.Changeset.t, map, map) :: Ecto.Changeset.t
   def prepare_custom_fields(changeset, params, opts \\ %{}) do

--- a/lib/attribrutex.ex
+++ b/lib/attribrutex.ex
@@ -116,7 +116,7 @@ defmodule Attribrutex do
         timestamps()
       end
 
-      def changeset(struct, params \\ %{}) do
+      def changeset(struct, params \\ %{}, opts \\ %{}) do
         struct
         |> cast(params, [:email])
         |> validate_required([:email])

--- a/lib/attribrutex.ex
+++ b/lib/attribrutex.ex
@@ -97,6 +97,36 @@ defmodule Attribrutex do
   defp select_custom_fields(query, :keys), do: from c in query, select: c.key
   defp select_custom_fields(query, :fields), do: from c in query, select: %{key: c.key, type: c.field_type}
 
+  @doc """
+  Use it to manage custom_fields on building the changesets.
+  You can use the opts like on `list_custom_fields_for/2` to set the
+  `context_id` and `context_type`
+
+  ## Example:
+
+    ```
+    defmodule AttribrutexUser do
+      use Ecto.Schema
+      import Ecto.Changeset
+
+      schema "users" do
+        field :email, :string
+        field :custom_fields, :map, default: %{}
+
+        timestamps()
+      end
+
+      def changeset(struct, params \\ %{}) do
+        struct
+        |> cast(params, [:email])
+        |> validate_required([:email])
+        |> Attribrutex.prepare_custom_fields(params, opts)
+      end
+    end
+    ```
+
+  """
+  @spec prepare_custom_fields(Ecto.Changeset.t, map, map) :: Ecto.Changeset.t
   def prepare_custom_fields(changeset, params, opts \\ %{}) do
     with opts           <- Map.put(opts, :mode, :fields),
          custom_fields  <- list_custom_fields_for(changeset.data.__struct__, opts),

--- a/lib/attribrutex.ex
+++ b/lib/attribrutex.ex
@@ -133,7 +133,7 @@ defmodule Attribrutex do
          custom_params  <- get_custom_params(custom_fields, params)
     do
       Enum.reduce(custom_params, changeset, fn(custom_param, changeset) ->
-        changeset = Changeset.put(changeset, custom_param)
+        Changeset.put(changeset, custom_param)
       end)
     end
   end

--- a/lib/attribrutex.ex
+++ b/lib/attribrutex.ex
@@ -56,7 +56,6 @@ defmodule Attribrutex do
     insert_custom_field(attrs)
   end
 
-
   defp insert_custom_field(attrs) do
     with changeset <- CustomField.changeset(%CustomField{}, attrs) do
       @repo.insert(changeset)
@@ -150,8 +149,7 @@ defmodule Attribrutex do
   end
 
   defp get_custom_params(custom_fields, params) do
-    custom_fields
-    |> Enum.reduce([], fn(%{key: key, type: type}, custom_params) ->
+    Enum.reduce(custom_fields, [], fn(%{key: key, type: type}, custom_params) ->
       if value = params[field_name(key)] do
         with new_entry <- %{key: key_atom(key), value: value, type: type} do
           List.insert_at(custom_params, -1, new_entry)

--- a/lib/attribrutex.ex
+++ b/lib/attribrutex.ex
@@ -102,7 +102,7 @@ defmodule Attribrutex do
          custom_fields  <- list_custom_fields_for(changeset.data.__struct__, opts),
          custom_params  <- get_custom_params(custom_fields, params)
     do
-      Enum.each(custom_params, fn  custom_param ->
+      Enum.reduce(custom_params, changeset, fn(custom_param, changeset) ->
         changeset = Changeset.put(changeset, custom_param)
       end)
     end
@@ -111,13 +111,19 @@ defmodule Attribrutex do
   defp get_custom_params(custom_fields, params) do
     custom_fields
     |> Enum.reduce([], fn(%{key: key, type: type}, custom_params) ->
-      if value = params[Atom.to_string(key)] do
-        with new_entry <- %{key: key, value: value, type: type} do
+      if value = params[field_name(key)] do
+        with new_entry <- %{key: key_atom(key), value: value, type: type} do
           List.insert_at(custom_params, -1, new_entry)
         end
       end
     end)
   end
+
+  defp field_name(field) when is_atom(field), do: Atom.to_string(field)
+  defp field_name(field) when is_bitstring(field), do: field
+
+  defp key_atom(key) when is_atom(key), do: key
+  defp key_atom(key) when is_bitstring(key), do: String.to_atom(key)
 
   defp module_name(module), do: module |> Module.split |> List.last
 end

--- a/lib/attribrutex/changeset.ex
+++ b/lib/attribrutex/changeset.ex
@@ -8,7 +8,6 @@ defmodule Attribrutex.Changeset do
   defp validate(value, :string), do: is_bitstring(value)
   defp validate(value, :integer), do: is_integer(value)
 
-  defp manage_value(valid?, changeset, key, value)
   defp manage_value(false, changeset, key, value) do
     Ecto.Changeset.add_error(changeset, :custom_fields, "Bad data type", custom_field: key)
   end

--- a/lib/attribrutex/changeset.ex
+++ b/lib/attribrutex/changeset.ex
@@ -8,15 +8,14 @@ defmodule Attribrutex.Changeset do
   defp validate(value, :string), do: is_bitstring(value)
   defp validate(value, :integer), do: is_integer(value)
 
-  defp manage_value(false, changeset, key, value) do
+  defp manage_value(false, changeset, key, _value) do
     Ecto.Changeset.add_error(changeset, :custom_fields, "Bad data type", custom_field: key)
   end
   defp manage_value(true, changeset, key, value) do
     with custom_fields <- custom_fields_changes(changeset, key, value),
-         changes <- Map.put(changeset.changes, :custom_fields, custom_fields),
-         changeset <- Map.put(changeset, :changes, changes)
+         changes <- Map.put(changeset.changes, :custom_fields, custom_fields)
     do
-      changeset
+      Map.put(changeset, :changes, changes)
     end
   end
 

--- a/lib/attribrutex/changeset.ex
+++ b/lib/attribrutex/changeset.ex
@@ -1,5 +1,5 @@
 defmodule Attribrutex.Changeset do
-  def put(changeset, %{key: key, type: type}, value) do
+  def put(changeset, %{key: key, value: value, type: type}) do
     value
     |> validate(type)
     |> manage_value(changeset, key, value)

--- a/lib/attribrutex/changeset.ex
+++ b/lib/attribrutex/changeset.ex
@@ -1,0 +1,31 @@
+defmodule Attribrutex.Changeset do
+  def put(changeset, %{key: key, type: type}, value) do
+    value
+    |> validate(type)
+    |> manage_value(changeset, key, value)
+  end
+
+  defp validate(value, :string), do: is_bitstring(value)
+  defp validate(value, :integer), do: is_integer(value)
+
+  defp manage_value(valid?, changeset, key, value)
+  defp manage_value(false, changeset, key, value) do
+    Ecto.Changeset.add_error(changeset, :custom_fields, "Bad data type", custom_field: key)
+  end
+  defp manage_value(true, changeset, key, value) do
+    with custom_fields <- custom_fields_changes(changeset, key, value),
+         changes <- Map.put(changeset.changes, :custom_fields, custom_fields),
+         changeset <- Map.put(changeset, :changes, changes)
+    do
+      changeset
+    end
+  end
+
+  defp custom_fields_changes(changeset, key, value) do
+    changeset
+    |> fetch_custom_fields
+    |> Map.put(key, value)
+  end
+
+  defp fetch_custom_fields(changeset), do: changeset.data.custom_fields || %{}
+end

--- a/lib/mix/tasks/attribrutex/migrate.ex
+++ b/lib/mix/tasks/attribrutex/migrate.ex
@@ -17,7 +17,7 @@ defmodule Mix.Tasks.Attribrutex.Migrate do
 
       def change do
         alter table(:#{table}) do
-          add :custom_fields, :jsonb
+          add :custom_fields, :jsonb, null: false
         end
 
         create index(:#{table}, [:custom_fields], using: "gin")
@@ -25,5 +25,4 @@ defmodule Mix.Tasks.Attribrutex.Migrate do
     end
     """
   end
-
 end

--- a/test/attribrutex/changeset_test.exs
+++ b/test/attribrutex/changeset_test.exs
@@ -12,7 +12,7 @@ defmodule Attribrutex.ChangesetTest do
 
   test "put/3 with valid value" do
     changeset = User.changeset(%User{}, %{email: "asdf@asdf.com"})
-    changeset = Changeset.put(changeset, %{key: :location, type: :string}, "Madrid")
+    changeset = Changeset.put(changeset, %{key: :location, value: "Madrid", type: :string})
     assert changeset.changes == %{
       custom_fields: %{location: "Madrid"},
       email: "asdf@asdf.com"
@@ -21,7 +21,7 @@ defmodule Attribrutex.ChangesetTest do
 
   test "put/3 with invalid value" do
     changeset = User.changeset(%User{}, %{email: "asdf@asdf.com"})
-    changeset = Changeset.put(changeset, %{key: :salary, type: :integer}, "Madrid")
+    changeset = Changeset.put(changeset, %{key: :salary, value: "Madrid", type: :integer})
     refute changeset.valid?
   end
 end

--- a/test/attribrutex/changeset_test.exs
+++ b/test/attribrutex/changeset_test.exs
@@ -1,0 +1,27 @@
+defmodule Attribrutex.ChangesetTest do
+  use ExUnit.Case
+  alias Attribrutex.Changeset
+  alias AttribrutexUser, as: User
+
+  @repo Attribrutex.RepoClient.repo
+
+  setup do
+    @repo.delete_all(Attribrutex.CustomField)
+    :ok
+  end
+
+  test "put/3 with valid value" do
+    changeset = User.changeset(%User{}, %{email: "asdf@asdf.com"})
+    changeset = Changeset.put(changeset, %{key: :location, type: :string}, "Madrid")
+    assert changeset.changes == %{
+      custom_fields: %{location: "Madrid"},
+      email: "asdf@asdf.com"
+    }
+  end
+
+  test "put/3 with invalid value" do
+    changeset = User.changeset(%User{}, %{email: "asdf@asdf.com"})
+    changeset = Changeset.put(changeset, %{key: :salary, type: :integer}, "Madrid")
+    refute changeset.valid?
+  end
+end

--- a/test/attribrutex_test.exs
+++ b/test/attribrutex_test.exs
@@ -82,7 +82,8 @@ defmodule AttribrutexTest do
     {_, result} = @repo.insert(changeset)
 
     assert changeset.changes.custom_fields.location == "Madrid"
-    assert result.custom_fields == %{location: "Madrid"}
+    assert result.email == "asdf@asdf.com"
+    assert result.custom_fields.location == "Madrid"
   end
 
   test "prepare_custom_fields/3 with invalid attributes" do
@@ -94,5 +95,30 @@ defmodule AttribrutexTest do
 
     refute changeset.valid?
     assert status == :error
+  end
+
+  test "prepare_custom_fields/3 from model changeset" do
+    Attribrutex.create_custom_field("location", :string, AttribrutexUser)
+    changeset = AttribrutexUser.custom_fields_changeset(%AttribrutexUser{}, %{"email" => "asdf@asdf.com", "location" => "Madrid"})
+    {_, result} = @repo.insert(changeset)
+    assert changeset.changes.custom_fields.location == "Madrid"
+    assert result.email == "asdf@asdf.com"
+    assert result.custom_fields.location ==  "Madrid"
+  end
+
+  test "prepare_custom_fields/3 from model changeset filters not present params" do
+    {_, result} = @repo.insert(AttribrutexUser.custom_fields_changeset(%AttribrutexUser{}, %{"email" => "asdf@asdf.com", "location" => "Madrid"}))
+    assert result.email == "asdf@asdf.com"
+    assert result.custom_fields == %{}
+  end
+
+  test "prepare_custom_fields/3 from model changeset works on update" do
+    Attribrutex.create_custom_field("location", :string, AttribrutexUser)
+    {_, struct} = @repo.insert(AttribrutexUser.custom_fields_changeset(%AttribrutexUser{}, %{"email" => "asdf@asdf.com", "location" => "Madrid"}))
+
+    {_, result} = @repo.update(AttribrutexUser.custom_fields_changeset(struct, %{"email" => "update@update.com", "location" => "Brasil"}))
+
+    assert result.email == "update@update.com"
+    assert result.custom_fields.location == "Brasil"
   end
 end

--- a/test/attribrutex_test.exs
+++ b/test/attribrutex_test.exs
@@ -74,14 +74,25 @@ defmodule AttribrutexTest do
     assert custom_field.type == :integer
   end
 
-  test "prepare_custom_fields/3" do
+  test "prepare_custom_fields/3 with valid attributes" do
     Attribrutex.create_custom_field("location", :string, AttribrutexUser)
     changeset = AttribrutexUser.changeset(%AttribrutexUser{}, %{email: "asdf@asdf.com"})
 
-    changeset = Attribrutex.prepare_custom_fields(changeset, %{location: "Madrid"})
+    changeset = Attribrutex.prepare_custom_fields(changeset, %{"location" => "Madrid"})
     {_, result} = @repo.insert(changeset)
 
     assert changeset.changes.custom_fields.location == "Madrid"
     assert result.custom_fields == %{location: "Madrid"}
+  end
+
+  test "prepare_custom_fields/3 with invalid attributes" do
+    Attribrutex.create_custom_field("location", :string, AttribrutexUser)
+    changeset = AttribrutexUser.changeset(%AttribrutexUser{}, %{email: "asdf@asdf.com"})
+
+    changeset = Attribrutex.prepare_custom_fields(changeset, %{"location" => 23})
+    {status, _} = @repo.insert(changeset)
+
+    refute changeset.valid?
+    assert status == :error
   end
 end

--- a/test/attribrutex_test.exs
+++ b/test/attribrutex_test.exs
@@ -73,4 +73,15 @@ defmodule AttribrutexTest do
     assert custom_field.key  == "stuff"
     assert custom_field.type == :integer
   end
+
+  test "prepare_custom_fields/3" do
+    Attribrutex.create_custom_field("location", :string, AttribrutexUser)
+    changeset = AttribrutexUser.changeset(%AttribrutexUser{}, %{email: "asdf@asdf.com"})
+
+    changeset = Attribrutex.prepare_custom_fields(changeset, %{location: "Madrid"})
+    {_, result} = @repo.insert(changeset)
+
+    assert changeset.changes.custom_fields.location == "Madrid"
+    assert result.custom_fields == %{location: "Madrid"}
+  end
 end

--- a/test/attribrutex_test.exs
+++ b/test/attribrutex_test.exs
@@ -97,6 +97,29 @@ defmodule AttribrutexTest do
     assert status == :error
   end
 
+  test "prepare_custom_fields/3 with context" do
+    Attribrutex.create_custom_field("location", :string, AttribrutexUser, context_id: 1, context_type: "User" )
+    changeset = AttribrutexUser.changeset(%AttribrutexUser{}, %{email: "asdf@asdf.com"})
+
+    changeset = Attribrutex.prepare_custom_fields(changeset, %{"location" => "Madrid"}, %{context_id: 1, context_type: "User"})
+    {_, result} = @repo.insert(changeset)
+
+    assert changeset.changes.custom_fields.location == "Madrid"
+    assert result.email == "asdf@asdf.com"
+    assert result.custom_fields.location == "Madrid"
+  end
+
+  test "prepare_custom_fields/3 with bad context" do
+    Attribrutex.create_custom_field("location", :string, AttribrutexUser, context_id: 1, context_type: "User" )
+    changeset = AttribrutexUser.changeset(%AttribrutexUser{}, %{email: "asdf@asdf.com"})
+
+    changeset = Attribrutex.prepare_custom_fields(changeset, %{"location" => "Madrid"}, %{context_id: 1, context_type: "Location"})
+    {_, result} = @repo.insert(changeset)
+
+    assert result.email == "asdf@asdf.com"
+    assert result.custom_fields == %{}
+  end
+
   test "prepare_custom_fields/3 from model changeset" do
     Attribrutex.create_custom_field("location", :string, AttribrutexUser)
     changeset = AttribrutexUser.custom_fields_changeset(%AttribrutexUser{}, %{"email" => "asdf@asdf.com", "location" => "Madrid"})
@@ -121,4 +144,5 @@ defmodule AttribrutexTest do
     assert result.email == "update@update.com"
     assert result.custom_fields.location == "Brasil"
   end
+
 end

--- a/test/support/models.ex
+++ b/test/support/models.ex
@@ -14,4 +14,11 @@ defmodule AttribrutexUser do
     |> cast(params, [:email])
     |> validate_required([:email])
   end
+
+  def custom_fields_changeset(struct, params \\ %{}, opts \\ %{}) do
+    struct
+    |> cast(params, [:email])
+    |> validate_required([:email])
+    |> Attribrutex.prepare_custom_fields(params, opts)
+  end
 end


### PR DESCRIPTION
## What does this PR do?
Adds `prepare_custom_fields/3` to manage custom fields in the changeset.

The purpose of this function is that people add the function on the changeset function on their models to automatically deal with custom_params and changeset

You can see the example here: https://github.com/bizneo/Attribrutex/pull/6/files#diff-ad98f95e92d70b31d34d23a5486af0dbR123

## Should we do something before? (migrations, seeds, ...)
If you've installed the project before, please, drop the test database

## Any background context you want to provide?
The `prepare_custom_fields/3` function follows the next steps:
- Fetch a list of custom fields based on changeset struct module and the opts (context if it exists)
- Filter the params to get only the fields that exists on the DB
- Call to `Attribrutex.Changeset.put/2` to add fields to the changeset
- Before add to the changeset, it need to be validated. On validation fail it will be added as an error.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)ese
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Review checklist
- [ ] Code follows the code style of this project.
- [ ] The changes requires a change to the documentation.
- [x] The documentation has been changed accordingly.
- [x] Added tests to cover changes.
- [x] All new and existing tests passed.
